### PR TITLE
Update to Node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,5 +5,5 @@ inputs:
   payload:
     description: Raw Slack incoming webhook payload
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'lib/main.js'


### PR DESCRIPTION
Node12 is being deprecated for github actions.

I got the following failure on CI

https://github.com/Shopify/ruby/actions/runs/3716253253

Links here: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

I haven't tested this. Just figured I'd make the PR with the change as a way of letting you know.